### PR TITLE
Added npm build and tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build CLI
@@ -25,8 +29,8 @@ jobs:
           name: pg0-macos
           path: target/release/pg0
 
-  sdk-tests:
-    name: SDK Tests (macOS)
+  python-sdk-tests:
+    name: Python SDK Tests (macOS)
     needs: build
     runs-on: macos-latest
     steps:
@@ -55,6 +59,43 @@ jobs:
           export PATH="$HOME/.local/bin:$PATH"
           uv pip install --system -e ".[dev]"
           pytest tests/ -v
+
+  node-sdk-tests:
+    name: Node.js SDK Tests (macOS)
+    needs: build
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download CLI
+        uses: actions/download-artifact@v4
+        with:
+          name: pg0-macos
+          path: ~/.local/bin
+
+      - name: Make CLI executable
+        run: chmod +x ~/.local/bin/pg0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: sdk/node/package-lock.json
+
+      - name: Install dependencies
+        working-directory: sdk/node
+        run: npm ci
+
+      - name: Build
+        working-directory: sdk/node
+        run: npm run build
+
+      - name: Run tests
+        working-directory: sdk/node
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          npm test
 
   # Docker tests - one job per platform, runs both CLI and Python SDK tests
   # Note: ARM64 tests are skipped because QEMU emulation is too slow for PostgreSQL setup

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: sdk/node/package-lock.json
 
       - name: Install dependencies
         working-directory: sdk/node

--- a/sdk/node/dist/src/index.js
+++ b/sdk/node/dist/src/index.js
@@ -153,7 +153,8 @@ function findPg0Sync() {
     // Check PATH
     const { execSync } = require("child_process");
     try {
-        const result = execSync("which pg0 2>/dev/null || where pg0 2>nul", { encoding: "utf-8" });
+        const cmd = process.platform === "win32" ? "where pg0" : "which pg0";
+        const result = execSync(cmd, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] });
         if (result.trim())
             return result.trim().split("\n")[0];
     }
@@ -181,7 +182,8 @@ async function findPg0() {
     // Check PATH
     const { execSync } = require("child_process");
     try {
-        const result = execSync("which pg0 2>/dev/null || where pg0 2>nul", { encoding: "utf-8" });
+        const cmd = process.platform === "win32" ? "where pg0" : "which pg0";
+        const result = execSync(cmd, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] });
         if (result.trim())
             return result.trim().split("\n")[0];
     }

--- a/sdk/node/src/index.ts
+++ b/sdk/node/src/index.ts
@@ -189,7 +189,8 @@ function findPg0Sync(): string {
   // Check PATH
   const { execSync } = require("child_process");
   try {
-    const result = execSync("which pg0 2>/dev/null || where pg0 2>nul", { encoding: "utf-8" });
+    const cmd = process.platform === "win32" ? "where pg0" : "which pg0";
+    const result = execSync(cmd, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] });
     if (result.trim()) return result.trim().split("\n")[0];
   } catch {
     // Not in PATH
@@ -221,7 +222,8 @@ async function findPg0(): Promise<string> {
   // Check PATH
   const { execSync } = require("child_process");
   try {
-    const result = execSync("which pg0 2>/dev/null || where pg0 2>nul", { encoding: "utf-8" });
+    const cmd = process.platform === "win32" ? "where pg0" : "which pg0";
+    const result = execSync(cmd, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] });
     if (result.trim()) return result.trim().split("\n")[0];
   } catch {
     // Not in PATH


### PR DESCRIPTION
  CI improvements:
  - Added concurrency settings to cancel in-progress runs
  - Renamed sdk-tests → python-sdk-tests
  - Added node-sdk-tests job with npm caching
  - Added npm caching to release workflow

  Bug fix in sdk/node/src/index.ts:
  - Fixed cross-platform which/where detection that was creating a nul file